### PR TITLE
Revamp GitHub page with animated dynamic portfolio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
-# Hey guys!
+# Ashwin's GitHub Page
 
-Visit [designedbyashw.in](http://designedbyashw.in) to see my main page
+This repository powers [ashwin-pc.github.io](https://ashwin-pc.github.io).
+
+The landing page fetches profile information and recent projects from the GitHub API, dynamically tinting the theme to match the profile picture.
+Sections and project cards sit on a subtle glassmorphic layer with animated reveals.

--- a/assets/script.js
+++ b/assets/script.js
@@ -20,7 +20,7 @@ function deriveAccentFromImage(img) {
   document.documentElement.style.setProperty('--bg1', `rgb(${(r * 0.1) | 0}, ${(g * 0.1) | 0}, ${(b * 0.1) | 0})`);
   document.documentElement.style.setProperty('--bg2', `rgb(${(r * 0.25) | 0}, ${(g * 0.25) | 0}, ${(b * 0.25) | 0})`);
   document.documentElement.style.setProperty('--bg3', `rgb(${(r * 0.5) | 0}, ${(g * 0.5) | 0}, ${(b * 0.5) | 0})`);
-  document.documentElement.style.setProperty('--bg4', `rgb(${(r * 0.25) | 0}, ${(g * 0.25) | 0}, ${(b * 0.25) | 0})`);
+  document.documentElement.style.setProperty('--bg4', `rgb(${(r * 0.1) | 0}, ${(g * 0.1) | 0}, ${(b * 0.1) | 0})`);
 }
 
 async function fetchProfile() {

--- a/assets/script.js
+++ b/assets/script.js
@@ -1,0 +1,84 @@
+function deriveAccentFromImage(img) {
+  const canvas = document.createElement('canvas');
+  canvas.width = img.naturalWidth;
+  canvas.height = img.naturalHeight;
+  const ctx = canvas.getContext('2d');
+  ctx.drawImage(img, 0, 0);
+  const { data } = ctx.getImageData(0, 0, canvas.width, canvas.height);
+  let r = 0, g = 0, b = 0;
+  const len = data.length / 4;
+  for (let i = 0; i < data.length; i += 4) {
+    r += data[i];
+    g += data[i + 1];
+    b += data[i + 2];
+  }
+  r = Math.round(r / len);
+  g = Math.round(g / len);
+  b = Math.round(b / len);
+  const accent = `rgb(${r}, ${g}, ${b})`;
+  document.documentElement.style.setProperty('--accent', accent);
+  document.documentElement.style.setProperty('--bg1', `rgb(${(r * 0.1) | 0}, ${(g * 0.1) | 0}, ${(b * 0.1) | 0})`);
+  document.documentElement.style.setProperty('--bg2', `rgb(${(r * 0.25) | 0}, ${(g * 0.25) | 0}, ${(b * 0.25) | 0})`);
+  document.documentElement.style.setProperty('--bg3', `rgb(${(r * 0.5) | 0}, ${(g * 0.5) | 0}, ${(b * 0.5) | 0})`);
+  document.documentElement.style.setProperty('--bg4', `rgb(${(r * 0.25) | 0}, ${(g * 0.25) | 0}, ${(b * 0.25) | 0})`);
+}
+
+async function fetchProfile() {
+  const res = await fetch('https://api.github.com/users/ashwin-pc');
+  const data = await res.json();
+  const avatar = document.getElementById('avatar');
+  avatar.crossOrigin = 'anonymous';
+  avatar.src = data.avatar_url;
+  avatar.onload = () => deriveAccentFromImage(avatar);
+  document.getElementById('name').textContent = data.name;
+  document.getElementById('bio').textContent = data.bio;
+  document.getElementById('company').textContent = data.company || '';
+  document.getElementById('location').textContent = data.location || '';
+  const blog = document.getElementById('blog');
+  if (data.blog) {
+    blog.textContent = data.blog.replace(/^https?:\/\//, '');
+    blog.href = data.blog;
+  } else {
+    blog.parentElement.style.display = 'none';
+  }
+  document.querySelector('.hero').classList.add('visible');
+}
+
+async function fetchRepos() {
+  const res = await fetch('https://api.github.com/users/ashwin-pc/repos?sort=updated&per_page=6');
+  const repos = await res.json();
+  const grid = document.getElementById('projects-grid');
+  repos.forEach(repo => {
+    const card = document.createElement('a');
+    card.href = repo.html_url;
+    card.target = '_blank';
+    card.className = 'project-card glass hidden';
+    card.innerHTML = `
+      <h3>${repo.name}</h3>
+      <p>${repo.description || ''}</p>
+      <span class="language">${repo.language || ''}</span>
+    `;
+    grid.appendChild(card);
+  });
+}
+
+function revealOnScroll() {
+  const observer = new IntersectionObserver(entries => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('visible');
+        observer.unobserve(entry.target);
+      }
+    });
+  }, { threshold: 0.1 });
+
+  document.querySelectorAll('.hidden').forEach(el => observer.observe(el));
+}
+
+async function init() {
+  await fetchProfile();
+  await fetchRepos();
+  revealOnScroll();
+}
+
+init();

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,0 +1,104 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap');
+
+:root {
+  --accent: #cddd01;
+  --bg1: #0b0c0a;
+  --bg2: #1a1f0f;
+  --bg3: #3a3f16;
+  --bg4: #0b0c0a;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', sans-serif;
+  background: linear-gradient(-45deg, var(--bg1), var(--bg2), var(--bg3), var(--bg4));
+  background-size: 400% 400%;
+  animation: gradient 20s ease infinite;
+  color: #fff;
+}
+
+@keyframes gradient {
+  0% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+}
+
+.glass {
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border-radius: 12px;
+  box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
+}
+
+.hero {
+  text-align: center;
+  padding: 6rem 1rem;
+  max-width: 900px;
+  margin: 2rem auto;
+}
+
+.avatar {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  border: 3px solid var(--accent);
+  margin-bottom: 1rem;
+}
+
+h1 {
+  margin: 0;
+  font-size: 2.5rem;
+}
+
+.section {
+  padding: 4rem 1rem;
+  max-width: 900px;
+  margin: 2rem auto;
+}
+
+.projects-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1.5rem;
+  margin-top: 2rem;
+}
+
+.project-card {
+  padding: 1.5rem;
+  text-decoration: none;
+  color: inherit;
+  transition: transform 0.3s ease, background 0.3s ease;
+}
+
+.project-card:hover {
+  transform: translateY(-5px);
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.btn {
+  display: inline-block;
+  margin-top: 2rem;
+  padding: 0.75rem 1.5rem;
+  background: var(--accent);
+  color: #000;
+  border-radius: 5px;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.hidden {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+}
+
+.visible {
+  opacity: 1;
+  transform: translateY(0);
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ashwin P Chandran</title>
+  <link rel="stylesheet" href="assets/style.css" />
+</head>
+<body>
+  <header class="hero glass hidden">
+    <img id="avatar" class="avatar" alt="Profile picture" />
+    <h1 id="name"></h1>
+    <p id="bio"></p>
+    <a class="btn" href="https://github.com/ashwin-pc" target="_blank" rel="noopener">Follow on GitHub</a>
+  </header>
+
+  <section id="about" class="section glass hidden">
+    <h2>About</h2>
+    <p><span id="company"></span> &mdash; <span id="location"></span></p>
+    <p>More on <a id="blog" href="#" target="_blank" rel="noopener"></a></p>
+  </section>
+
+  <section id="projects" class="section glass hidden">
+    <h2>Projects</h2>
+    <div id="projects-grid" class="projects-grid"></div>
+  </section>
+
+  <section id="contact" class="section glass hidden">
+  <h2>Contact</h2>
+  <p>
+    Reach out on <a href="https://github.com/ashwin-pc" target="_blank" rel="noopener">GitHub</a>
+    or visit
+    <a href="https://designedbyashw.in" target="_blank" rel="noopener">designedbyashw.in</a>.
+  </p>
+</section>
+
+  <script src="assets/script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Auto-tint the portfolio's accent and background gradient from the GitHub avatar image
- Apply a reusable glass class for hero, sections, and project cards to introduce a subtle glassmorphic look
- Document dynamic avatar-based theming and glass layers in the README

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_6896de1ed5008329b421b28a94f833b7